### PR TITLE
Fix message about applying no pyrovision option

### DIFF
--- a/generate.bat
+++ b/generate.bat
@@ -238,7 +238,7 @@ if %soundscapes% EQU 1 (
 	echo done
 )
 if %mtp% EQU 1 (
-	echo removing pyrovision textures
+	echo adding mtp.cfg
 	call dev\generators\scripts_copy.bat mtp.cfg cfg
 	echo "no pyrovision textures" >> dev\current_options.txt
 	echo done

--- a/generate.bat
+++ b/generate.bat
@@ -238,7 +238,7 @@ if %soundscapes% EQU 1 (
 	echo done
 )
 if %mtp% EQU 1 (
-	echo removing soundscapes
+	echo removing pyrovision textures
 	call dev\generators\scripts_copy.bat mtp.cfg cfg
 	echo "no pyrovision textures" >> dev\current_options.txt
 	echo done


### PR DESCRIPTION
Script prints "removing soundscapes" when actually removing pyrovision textures.
I think you probably forgot to fix the message when you copied this code block:
```
if %soundscapes% EQU 1 (
	echo removing soundscapes
	call dev\generators\scripts_copy.bat soundscapes_manifest.txt scripts
	echo "no soundscapes" >> dev\current_options.txt
	echo done
)
if %mtp% EQU 1 (
	echo removing soundscapes
	call dev\generators\scripts_copy.bat mtp.cfg cfg
	echo "no pyrovision textures" >> dev\current_options.txt
	echo done
)
```

![tf2clean1](https://user-images.githubusercontent.com/1074478/116291154-f1e53800-a79c-11eb-940f-6fca51b5fa75.png)
![tf2clean2](https://user-images.githubusercontent.com/1074478/116291156-f27dce80-a79c-11eb-92cf-90814a678890.png)
