### PR TITLE
Vpk tga fix

### DIFF
--- a/generate.bat
+++ b/generate.bat
@@ -251,9 +251,9 @@ if %fullbright% EQU 1 (
 	echo done
 )
 
+:DONE
 :: DELETE TGA FILES TO REDUCE VPK SIZE
 del /S materials/*.tga
 
-:DONE
 echo thank you for using Clean TF2+
 pause

--- a/generate.bat
+++ b/generate.bat
@@ -251,6 +251,9 @@ if %fullbright% EQU 1 (
 	echo done
 )
 
+:: DELETE TGA FILES TO REDUCE VPK SIZE
+del /S materials/*.tga
+
 :DONE
 echo thank you for using Clean TF2+
 pause

--- a/generate.sh
+++ b/generate.sh
@@ -305,4 +305,7 @@ if [ $mtp == 1 ]; then
 	echo done
 fi
 
+# DELETE TGA FILES TO REDUCE VPK SIZE
+find materials/ -name "*.tga" -type f -delete
+
 echo thank you for using Clean TF2+


### PR DESCRIPTION
Found that the generated TGA files were also being packed into the VPK, increasing its' size. The generate scripts should now delete the TGA files after generation is finished, tested on my linux machine and seems to work, I have included the same patch for the windows script but haven't been able to test it myself but it should work.