### PR TITLE
[SHEBANG-FIX] Changed linux shebangs to bash instead of sh

### DIFF
--- a/dev/generators/models_null.sh
+++ b/dev/generators/models_null.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/bash 
 
 for line in $(cat $1); do
 	case "$line" in

--- a/dev/generators/textures_flat.sh
+++ b/dev/generators/textures_flat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/bash 
 
 for line in $(cat $1); do
 	case "$line" in

--- a/dev/lists/convert_linux.sh
+++ b/dev/lists/convert_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 mkdir linux
 for filename in *.txt; do

--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # VALIDITY CHECKING
 


### PR DESCRIPTION
Bash and Sh are different, this caused issues on ubuntu machines (they don't symlink bash to sh). Fixes #26