### PR TITLE
fix 'Invalid switch - "*.tga".' output in terminal

### DIFF
--- a/generate.bat
+++ b/generate.bat
@@ -253,7 +253,7 @@ if %fullbright% EQU 1 (
 
 :DONE
 :: DELETE TGA FILES TO REDUCE VPK SIZE
-del /S materials/*.tga
+del /S materials\*.tga
 
 echo thank you for using Clean TF2+
 pause


### PR DESCRIPTION
for some reason the del command wants you to specify subdirectories using a \ instead of a /